### PR TITLE
Fixed issue where env.reset() result wasn't split in test methods

### DIFF
--- a/rl_x/algorithms/aqe/flax/aqe.py
+++ b/rl_x/algorithms/aqe/flax/aqe.py
@@ -487,7 +487,7 @@ class AQE():
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/ddpg/flax/ddpg.py
+++ b/rl_x/algorithms/ddpg/flax/ddpg.py
@@ -395,7 +395,7 @@ class DDPG:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/dqn/flax/dqn.py
+++ b/rl_x/algorithms/dqn/flax/dqn.py
@@ -382,7 +382,7 @@ class DQN:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 action = get_action(self.critic_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(action))

--- a/rl_x/algorithms/droq/flax/droq.py
+++ b/rl_x/algorithms/droq/flax/droq.py
@@ -490,7 +490,7 @@ class DroQ():
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/espo/flax/espo.py
+++ b/rl_x/algorithms/espo/flax/espo.py
@@ -465,7 +465,7 @@ class ESPO:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/mpo/flax/mpo.py
+++ b/rl_x/algorithms/mpo/flax/mpo.py
@@ -640,7 +640,7 @@ class MPO():
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.train_state.agent_params.policy_params, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/redq/flax/redq.py
+++ b/rl_x/algorithms/redq/flax/redq.py
@@ -489,7 +489,7 @@ class REDQ():
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/sac/flax/sac.py
+++ b/rl_x/algorithms/sac/flax/sac.py
@@ -438,7 +438,7 @@ class SAC:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/sac/pytorch/sac.py
+++ b/rl_x/algorithms/sac/pytorch/sac.py
@@ -388,7 +388,7 @@ class SAC:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 with torch.no_grad():
                     processed_action = self.policy.get_deterministic_action(torch.tensor(state, dtype=torch.float32).to(self.device))

--- a/rl_x/algorithms/td3/flax/td3.py
+++ b/rl_x/algorithms/td3/flax/td3.py
@@ -445,7 +445,7 @@ class TD3:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))

--- a/rl_x/algorithms/tqc/flax/tqc.py
+++ b/rl_x/algorithms/tqc/flax/tqc.py
@@ -453,7 +453,7 @@ class TQC:
         for i in range(episodes):
             done = False
             episode_return = 0
-            state = self.env.reset()
+            state, _ = self.env.reset()
             while not done:
                 processed_action = get_action(self.policy_state, state)
                 state, reward, terminated, truncated, info = self.env.step(jax.device_get(processed_action))


### PR DESCRIPTION
Hi,

the result of env.reset() wasn't split in several test methods, leading to exceptions when executing models. I haven't tested every combination but this should be a consistent bug in the changed algorithms. Feel free to use or ignore :)

Kind regards,
kit